### PR TITLE
Adds a standalone OS X template.

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+echo "Adding default SSH key for $USERNAME user.."
+mkdir -p "/Users/$USERNAME/.ssh"
+
+cat << EOF > "/Users/$USERNAME/.ssh/authorized_keys"
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDY/apwGMmA6ZBnN7ezuNlpEhCmET1bkuyy1oKNo4/xDCyE2i8KAKBrSzKOGnjNNCtcQmVcslfJBizY0atX2o19WauZtgbNSsT8qCqqHZ3ha9riJW7ypxLh2wpTtFMfc78Sna+yA/ErWuQNMgKOFW7KU5S+sXtls1IfXloDSRm+q7GhmuwjLlN4Mk8y43mhyFe0ZO+NY09Xmc1yyy5w1urJuykFs6zcUkjQ5l3H5ZBPGJjDJ6KHXYsEcE6zDaa+4lZiWb7MaamU37W0Zm/ntIQUzDEP/XPOAC0NTdAsXI1dSltVX6NCLFUO9qHSSv9N9wPECuimJUt4wyYU4P1e//o5Gq0EIpNpiswEaJtlc9f0AEyzuQLdWYwtLW+ncIdK2Bm2nVCBYvBqQ2bB9cMdShVTEvTAlnSb3tavETxPTjXBefQaugsPeV67eEQhmeWValnQIcLtjd2JnktVHLw3bdH4cIUKsauE07TQzdkTyWRs9eyygz0kNMTtCq/wcMMuTGDv0Yhrc4lFNZ9OeHPmuMpx5CbnPhexaUXjqJq+KjLkBJ3DeWkS3anbYoK7UJrEQYYWPQjZcPj3vLHu4n1preO3uZ0fcrgtlwato20n83+sn0ieOgBz6t+jqekRyUFLCe/A401vUUlflGAm3N4UvbZfiLKq3qk2EPkKL+p4cC2ZPw==
+EOF
+
+chmod 700 "/Users/$USERNAME/.ssh"
+chmod 600 "/Users/$USERNAME/.ssh/authorized_keys"
+chown -R "$USERNAME" "/Users/$USERNAME/.ssh"
+
+echo "Enabling password-less sudo..."
+mkdir -p /etc/sudoers.d
+
+cat << EOF > /etc/sudoers.d/password_less
+ALL            ALL = (ALL) NOPASSWD: ALL
+EOF
+
+chmod 440 /etc/sudoers.d/password_less
+
+echo "Creating a group for the user..."
+dseditgroup -o create "$USERNAME"
+dseditgroup -o edit -a "$USERNAME" "$USERNAME"

--- a/standalone.json
+++ b/standalone.json
@@ -37,8 +37,7 @@
       "keep_registered": true,
 
       "prlctl": [
-        ["set", "{{.Name}}", "--memsize", "2048"],
-        ["set", "{{.Name}}", "--memquota", "512:2048"],
+        ["set", "{{.Name}}", "--memsize", "4096"],
         ["set", "{{.Name}}", "--cpus", "2"],
         ["set", "{{.Name}}", "--distribution", "macosx"],
         ["set", "{{.Name}}", "--3d-accelerate", "highest"],
@@ -72,8 +71,8 @@
 
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "memsize": "2048",
-        "numvcpus": "1",
+        "memsize": "4096",
+        "numvcpus": "2",
         "firmware": "efi",
         "keyboardAndMouseProfile": "macProfile",
         "smc.present": "TRUE",
@@ -113,7 +112,8 @@
         ["modifyvm", "{{.Name}}", "--firmware", "efi"],
         ["modifyvm", "{{.Name}}", "--hpet", "on"],
         ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
-        ["modifyvm", "{{.Name}}", "--memory", "2048"],
+        ["modifyvm", "{{.Name}}", "--memory", "4096"],
+        ["modifyvm", "{{.Name}}", "--cpus", "2"],
         ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
         ["modifyvm", "{{.Name}}", "--usbehci", "on"],
         ["modifyvm", "{{.Name}}", "--vram", "128"],

--- a/standalone.json
+++ b/standalone.json
@@ -1,0 +1,167 @@
+{
+  "variables": {
+    "iso_url": "OSX_InstallESD_10.11.1_15B42.dmg",
+    "provisioning_delay": "0",
+    "username": "vagrant",
+    "password": "vagrant",
+    "autologin": "false",
+    "update_system": "true",
+    "install_xcode_cli_tools": "true",
+
+    "chef_version": "none",
+    "facter_version": "none",
+    "hiera_version": "none",
+    "puppet_version": "none",
+    "puppet_agent_version": "none"
+  },
+
+  "builders": [
+    {
+      "vm_name": "osx-standalone-parallels",
+      "type": "parallels-iso",
+      "guest_os_type": "win-8",
+      "parallels_tools_flavor": "mac",
+
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "none",
+
+      "ssh_username": "{{user `username`}}",
+      "ssh_password": "{{user `password`}}",
+      "ssh_wait_timeout": "10000s",
+
+      "boot_wait": "5s",
+      "disk_size": 40960,
+
+      "shutdown_command": "echo '{{user `username`}}'|sudo -S shutdown -h now",
+
+      "keep_registered": true,
+
+      "prlctl": [
+        ["set", "{{.Name}}", "--memsize", "2048"],
+        ["set", "{{.Name}}", "--memquota", "512:2048"],
+        ["set", "{{.Name}}", "--cpus", "2"],
+        ["set", "{{.Name}}", "--distribution", "macosx"],
+        ["set", "{{.Name}}", "--3d-accelerate", "highest"],
+        ["set", "{{.Name}}", "--high-resolution", "off"],
+        ["set", "{{.Name}}", "--auto-share-camera", "off"],
+        ["set", "{{.Name}}", "--auto-share-bluetooth", "off"],
+        ["set", "{{.Name}}", "--on-window-close", "keep-running"],
+        ["set", "{{.Name}}", "--shf-host", "off"]
+      ]
+    },
+    {
+      "vm_name": "osx-standalone-vmware",
+      "type": "vmware-iso",
+      "guest_os_type": "darwin12-64",
+      "tools_upload_flavor": "darwin",
+
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "none",
+
+      "ssh_username": "{{user `username`}}",
+      "ssh_password": "{{user `password`}}",
+      "ssh_wait_timeout": "10000s",
+
+      "boot_wait": "2s",
+      "disk_size": 40960,
+
+      "shutdown_command": "echo '{{user `username`}}'|sudo -S shutdown -h now",
+
+      "keep_registered": true,
+      "skip_compaction": true,
+
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "2048",
+        "numvcpus": "1",
+        "firmware": "efi",
+        "keyboardAndMouseProfile": "macProfile",
+        "smc.present": "TRUE",
+        "hpet0.present": "TRUE",
+        "ich7m.present": "TRUE",
+        "ehci.present": "TRUE",
+        "usb.present": "TRUE"
+      }
+    },
+    {
+      "vm_name": "osx-standalone-virtualbox",
+      "type": "virtualbox-iso",
+      "guest_os_type": "MacOS1011_64",
+      "guest_additions_mode": "disable",
+
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "none",
+
+      "ssh_username": "{{user `username`}}",
+      "ssh_password": "{{user `password`}}",
+
+      "ssh_wait_timeout": "10000s",
+      "boot_wait": "2s",
+      "disk_size": 40960,
+      "iso_interface": "sata",
+      "hard_drive_interface": "sata",
+
+      "shutdown_command": "echo '{{user `username`}}'|sudo -S shutdown -h now",
+
+      "keep_registered": true,
+
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--audiocontroller", "hda"],
+        ["modifyvm", "{{.Name}}", "--boot1", "dvd"],
+        ["modifyvm", "{{.Name}}", "--boot2", "disk"],
+        ["modifyvm", "{{.Name}}", "--chipset", "ich9"],
+        ["modifyvm", "{{.Name}}", "--firmware", "efi"],
+        ["modifyvm", "{{.Name}}", "--hpet", "on"],
+        ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
+        ["modifyvm", "{{.Name}}", "--memory", "2048"],
+        ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
+        ["modifyvm", "{{.Name}}", "--usbehci", "on"],
+        ["modifyvm", "{{.Name}}", "--vram", "128"],
+        ["storagectl", "{{.Name}}", "--name", "IDE Controller", "--remove"]
+      ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell-local",
+      "command": "sleep {{user `provisioning_delay`}}"
+    },
+    {
+      "destination": "/private/tmp/set_kcpassword.py",
+      "source": "scripts/support/set_kcpassword.py",
+      "type": "file"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "USERNAME={{user `username`}}",
+        "PASSWORD={{user `password`}}",
+        "AUTOLOGIN={{user `autologin`}}",
+        "UPDATE_SYSTEM={{user `update_system`}}",
+        "INSTALL_XCODE_CLI_TOOLS={{user `install_xcode_cli_tools`}}",
+        "CHEF_VERSION={{user `chef_version`}}",
+        "FACTER_VERSION={{user `facter_version`}}",
+        "HIERA_VERSION={{user `hiera_version`}}",
+        "PUPPET_VERSION={{user `puppet_version`}}",
+        "PUPPET_AGENT_VERSION={{user `puppet_agent_version`}}"
+      ],
+      "scripts": [
+        "scripts/post-install.sh",
+        "scripts/vmware.sh",
+        "scripts/parallels.sh",
+
+        "scripts/xcode-cli-tools.sh",
+        "scripts/chef-omnibus.sh",
+        "scripts/puppet.sh",
+
+        "scripts/add-network-interface-detection.sh",
+        "scripts/autologin.sh",
+        "scripts/system-update.sh",
+        "scripts/shrink.sh"
+      ],
+
+      "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
+    }
+  ]
+}

--- a/vagrant.json
+++ b/vagrant.json
@@ -14,8 +14,7 @@
       "parallels_tools_flavor": "mac",
       "type": "parallels-iso",
       "prlctl": [
-        ["set", "{{.Name}}", "--memsize", "2048"],
-        ["set", "{{.Name}}", "--memquota", "512:2048"],
+        ["set", "{{.Name}}", "--memsize", "4096"],
         ["set", "{{.Name}}", "--cpus", "2"],
         ["set", "{{.Name}}", "--distribution", "macosx"],
         ["set", "{{.Name}}", "--3d-accelerate", "highest"],
@@ -42,8 +41,8 @@
       "type": "vmware-iso",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "memsize": "2048",
-        "numvcpus": "1",
+        "memsize": "4096",
+        "numvcpus": "2",
         "firmware": "efi",
         "keyboardAndMouseProfile": "macProfile",
         "smc.present": "TRUE",
@@ -76,7 +75,8 @@
         ["modifyvm", "{{.Name}}", "--firmware", "efi"],
         ["modifyvm", "{{.Name}}", "--hpet", "on"],
         ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
-        ["modifyvm", "{{.Name}}", "--memory", "2048"],
+        ["modifyvm", "{{.Name}}", "--memory", "4096"],
+        ["modifyvm", "{{.Name}}", "--cpus", "2"]
         ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
         ["modifyvm", "{{.Name}}", "--usbehci", "on"],
         ["modifyvm", "{{.Name}}", "--vram", "128"],


### PR DESCRIPTION
This outputs a VM which is left registered with the host and can either
be moved around or left in place.

It also adds a post-install script which configures an ssh key and
password-less sudo correctly.